### PR TITLE
fix(next/config): update glob in withNextConfig example

### DIFF
--- a/src/routes/(vertical)/docs/next/config/+page.svx
+++ b/src/routes/(vertical)/docs/next/config/+page.svx
@@ -118,6 +118,7 @@ export default serwist.withNextConfig((nextConfig) => ({
   globIgnores: [
     `${nextConfig.distDir}/server/pages/**/*.json`,
     `${nextConfig.distDir}/server/app/ignored.html`,
+    `${nextConfig.distDir}/server/app/_global-error*`
   ],
 }));
 ```


### PR DESCRIPTION
Add a glob in the withNextConfig documentation so that the global error page doesn't cause precaching to break worker installation.